### PR TITLE
Fixing the view problem made by a code block mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,6 @@ yarn dev
 node update-version.js
 ./release.sh
 ```
-```
-
-
 
 
 # Thanks


### PR DESCRIPTION
a ` ``` ` made a problem in last lines on `README.md`: "Thanks" and "Licences" showed as code

screenshot in Obsidian:
![image](https://github.com/EasyChris/obsidian-to-notion/assets/86428901/5cd2eac1-7f03-4ad2-993f-be9e303cc689)

now it is fixed