### PR TITLE
feat: add long text support

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -9,10 +9,10 @@ import {
 	Setting,
 	normalizePath
 } from "obsidian";
-import {addIcons}  from 'icon';
-import { Upload2Notion } from "Upload2Notion";
+import {addIcons} from 'icon';
+import {Upload2Notion} from "Upload2Notion";
 import {NoticeMConfig} from "Message";
-import { CLIENT_RENEG_LIMIT } from "tls";
+import {CLIENT_RENEG_LIMIT} from "tls";
 
 
 // Remember to rename these classes and interfaces!
@@ -24,9 +24,11 @@ interface PluginSettings {
 	notionID: string;
 	proxy: string;
 	allowTags: boolean;
+	allowNotionLink: boolean;
+	folderPath: string;
 }
 
-const langConfig =  NoticeMConfig( window.localStorage.getItem('language') || 'en')
+const langConfig = NoticeMConfig(window.localStorage.getItem('language') || 'en')
 
 const DEFAULT_SETTINGS: PluginSettings = {
 	notionAPI: "",
@@ -34,11 +36,14 @@ const DEFAULT_SETTINGS: PluginSettings = {
 	bannerUrl: "",
 	notionID: "",
 	proxy: "",
-	allowTags: false
+	allowTags: false,
+	allowNotionLink: false,
+	folderPath: "",
 };
 
 export default class ObsidianSyncNotionPlugin extends Plugin {
 	settings: PluginSettings;
+
 	async onload() {
 		await this.loadSettings();
 		addIcons();
@@ -70,46 +75,69 @@ export default class ObsidianSyncNotionPlugin extends Plugin {
 
 	}
 
-	onunload() {}
+	onunload() {
+	}
 
-	async upload(){
-		const { notionAPI, databaseID, allowTags } = this.settings;
-				if (notionAPI === "" || databaseID === "") {
-					new Notice(
-						"Please set up the notion API and database ID in the settings tab."
-					);
-					return;
-				}
-				const { markDownData, nowFile, tags } =await this.getNowFileMarkdownContent(this.app);
-
-
-				if (markDownData) {
-					const { basename } = nowFile;
-					const upload = new Upload2Notion(this);
-					const res = await upload.syncMarkdownToNotion(basename, allowTags, tags, markDownData, nowFile, this.app, this.settings)
-					if(res.status === 200){
-						new Notice(`${langConfig["sync-success"]}${basename}`)
-					}else {
-						new Notice(`${langConfig["sync-fail"]}${basename}`, 5000)
+	async upload() {
+		const {notionAPI, databaseID, allowTags} = this.settings;
+		if (notionAPI === "" || databaseID === "") {
+			new Notice(
+				"Please set up the notion API and database ID in the settings tab."
+			);
+			return;
+		}
+		const upload = new Upload2Notion(this);
+		const {markDownData, chunks, nowFile, tags} = await this.getNowFileMarkdownContent(this.app);
+		const frontmasster = app.metadataCache.getFileCache(nowFile)?.frontmatter
+		const notionID = frontmasster ? frontmasster.notionID : null
+		// 存在就先删除
+		if (notionID) {
+			await upload.deletePage(notionID)
+		}
+		try {
+			if (chunks) {
+				const {basename} = nowFile;
+				// create page
+				const res = await upload.syncMarkdownToNotion(basename, allowTags, tags, chunks[0], null)
+				let {id} = res.json
+				// append page
+				for (let i = 1; i < chunks.length; i++) {
+					const response = await upload.syncMarkdownToNotion(basename, allowTags, tags, chunks[i], id)
+					if (response.status != 200) {
+						new Notice(`${langConfig["sync-fail"]}${basename},please retry!`, 5000)
+						break
 					}
 				}
+				await upload.updateYamlInfo(markDownData, nowFile, res, app, this.settings)
+				new Notice(`${langConfig["sync-success"]}${basename}`)
+
+			} else {
+				new Notice('sync-fail,please check your file in obsidian')
+			}
+		} catch (Exception) {
+			new Notice('sync-fail,please retry')
+		}
 	}
 
 	async getNowFileMarkdownContent(app: App) {
 		const nowFile = app.workspace.getActiveFile();
-		const { allowTags } = this.settings;
+		const {allowTags} = this.settings;
 		let tags = []
 		try {
-			if(allowTags) {
+			if (allowTags) {
 				tags = app.metadataCache.getFileCache(nowFile).frontmatter.tags;
 			}
 		} catch (error) {
 			new Notice(langConfig["set-tags-fail"]);
 		}
+
 		if (nowFile) {
-			const markDownData = await nowFile.vault.read(nowFile);
+			let markDownData = await nowFile.vault.read(nowFile);
+			const upload = new Upload2Notion(this);
+			let chunks = upload.splitLongString(markDownData)
 			return {
 				markDownData,
+				chunks,
 				nowFile,
 				tags
 			};
@@ -141,64 +169,31 @@ class SampleSettingTab extends PluginSettingTab {
 	}
 
 	display(): void {
-		const { containerEl } = this;
+		const {containerEl} = this;
 
 		containerEl.empty();
 
-		containerEl.createEl("h2", {
-			text: "Settings for obsidian to notion plugin.",
+		containerEl.createEl("h1", {
+			text: "Public Settings",
 		});
+
 
 		new Setting(containerEl)
 			.setName("Notion API Token")
 			.setDesc("It's a secret")
-			.addText((text) =>{
+			.addText((text) => {
 				let t = text
-				.setPlaceholder("Enter your Notion API Token")
-				.setValue(this.plugin.settings.notionAPI)
-				.onChange(async (value) => {
-					this.plugin.settings.notionAPI = value;
-					await this.plugin.saveSettings();
-				})
+					.setPlaceholder("Enter your Notion API Token")
+					.setValue(this.plugin.settings.notionAPI)
+					.onChange(async (value) => {
+						this.plugin.settings.notionAPI = value;
+						await this.plugin.saveSettings();
+					})
 				// t.inputEl.type = 'password'
 				return t
 			});
 
-
-		const notionDatabaseID = new Setting(containerEl)
-			.setName("Database ID")
-			.setDesc("It's a secret")
-			.addText((text) => {
-				let t = text
-				.setPlaceholder("Enter your Database ID")
-				.setValue(this.plugin.settings.databaseID)
-				.onChange(async (value) => {
-					this.plugin.settings.databaseID = value;
-					await this.plugin.saveSettings();
-				})
-				// t.inputEl.type = 'password'
-				return t
-			}
-
-			);
-
-			// notionDatabaseID.controlEl.querySelector('input').type='password'
-
-			new Setting(containerEl)
-			.setName("Banner url(optional)")
-			.setDesc("page banner url(optional), default is empty, if you want to show a banner, please enter the url(like:https://raw.githubusercontent.com/EasyChris/obsidian-to-notion/ae7a9ac6cf427f3ca338a409ce6967ced9506f12/doc/2.png)")
-			.addText((text) =>
-				text
-					.setPlaceholder("Enter banner pic url: ")
-					.setValue(this.plugin.settings.bannerUrl)
-					.onChange(async (value) => {
-						this.plugin.settings.bannerUrl = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-
-			new Setting(containerEl)
+		new Setting(containerEl)
 			.setName("Notion ID(optional)")
 			.setDesc("Your notion ID(optional),share link likes:https://username.notion.site/,your notion id is [username]")
 			.addText((text) =>
@@ -212,7 +207,44 @@ class SampleSettingTab extends PluginSettingTab {
 			);
 
 
-			new Setting(containerEl)
+		containerEl.createEl("h1", {
+			text: "Settings for Obsidian to Notion plugin",
+		});
+
+
+		const notionDatabaseID = new Setting(containerEl)
+			.setName("Database ID")
+			.setDesc("It's a secret")
+			.addText((text) => {
+					let t = text
+						.setPlaceholder("Enter your Database ID")
+						.setValue(this.plugin.settings.databaseID)
+						.onChange(async (value) => {
+							this.plugin.settings.databaseID = value;
+							await this.plugin.saveSettings();
+						})
+					// t.inputEl.type = 'password'
+					return t
+				}
+			);
+
+		// notionDatabaseID.controlEl.querySelector('input').type='password'
+
+		new Setting(containerEl)
+			.setName("Banner url(optional)")
+			.setDesc("page banner url(optional), default is empty, if you want to show a banner, please enter the url(like:https://raw.githubusercontent.com/EasyChris/obsidian-to-notion/ae7a9ac6cf427f3ca338a409ce6967ced9506f12/doc/2.png)")
+			.addText((text) =>
+				text
+					.setPlaceholder("Enter banner pic url: ")
+					.setValue(this.plugin.settings.bannerUrl)
+					.onChange(async (value) => {
+						this.plugin.settings.bannerUrl = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+
+		new Setting(containerEl)
 			.setName("Convert tags(optional)")
 			.setDesc("Transfer the Obsidian tags to the Notion table. It requires the column with the name 'Tags'")
 			.addToggle((toggle) =>
@@ -223,6 +255,28 @@ class SampleSettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					})
 			);
+
+		new Setting(containerEl)
+			.setName("Insert Notion Link to YAML")
+			.setDesc("When complete share,it will add NotionLink to YAML")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.allowNotionLink)
+					.onChange(async (value) => {
+						this.plugin.settings.allowNotionLink = value;
+						await this.plugin.saveSettings();
+					}))
+
+		new Setting(containerEl)
+			.setName("Auto shared folder path")
+			.setDesc("The file under this path,will auto shared to Notion")
+			.addText((text) =>
+				text.setValue(this.plugin.settings.folderPath)
+					.onChange(async (value) => {
+						this.plugin.settings.folderPath = value;
+						await this.plugin.saveSettings();
+					}))
+
 
 	}
 }


### PR DESCRIPTION
In old version, when file  text is longer than NotionApi limit, it's will throw error and always sync fail.
I use a way to solve this problem is that split origin text into many chunks and then append these chunks in a loop into page. now  it's fixed.